### PR TITLE
fix(buffer): Correct buffer offset and length

### DIFF
--- a/src/buffer.ts
+++ b/src/buffer.ts
@@ -141,7 +141,7 @@ export function createWriteBuffer(): WriteBuffer {
 
 
 export function createReadBuffer(buf: BufferSource): ReadBuffer {
-	let view = new DataView(ArrayBuffer.isView(buf) ? buf.buffer : buf);
+	let view = ArrayBuffer.isView(buf) ? new DataView(buf.buffer, buf.byteOffset, buf.byteLength) : new DataView(buf);
 	let n = 0;
 	
 	return {


### PR DESCRIPTION
Use the byteOffset and byteLength fields to correctly offset into the buffer when creating the read buffer.