### PR TITLE
use available TextDecoder rather than loop to decode UTF8

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -429,27 +429,7 @@ function toUTF8(v: string): ArrayBuffer {
 }
 
 function fromUTF8(buf: ArrayBuffer): string {
-	const bin = new Uint8Array(buf);
-	let n: number, c: number, codepoints = [];
-	for(let i = 0; i < bin.length;) {
-		c = bin[i++];
-		n = 0;
-		switch(c & 0xf0) {
-		case 0xf0:  n = 3; break;
-		case 0xe0:  n = 2; break;
-		case 0xd0:
-		case 0xc0:  n = 1; break;
-		}
-
-		if(n !== 0) {
-			c &= (1 << (6-n)) - 1;
-			for(let k = 0; k < n; ++k) {
-				c = (c<<6) + (bin[i++] & 0x3f);
-			}
-		}
-		codepoints.push(c);
-	}
-	return String.fromCodePoint.apply(null, codepoints);
+	return (new TextDecoder('utf-8')).decode(buf);
 }
 
 function typeOf(v: any): Type<any> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -429,7 +429,7 @@ function toUTF8(v: string): ArrayBuffer {
 }
 
 function fromUTF8(buf: ArrayBuffer): string {
-	return (new TextDecoder('utf-8')).decode(buf);
+	return (new TextDecoder("utf-8")).decode(buf);
 }
 
 function typeOf(v: any): Type<any> {


### PR DESCRIPTION
I was having problems with very long strings and running into the recursion limit from String.fromCodePoint.apply(null, codepoints).

The entire logic of from UTF8 can now be replaced with the new builtin TextDecoder.decode function, I believe.  I have tested this and it works for my very long strings.